### PR TITLE
Update the pmClient.py for get_live_market_data Error

### DIFF
--- a/pmClient/pmClient.py
+++ b/pmClient/pmClient.py
@@ -533,7 +533,7 @@ class PMClient(ApiService, Constants):
         """
         params = {
             'mode_type': mode_type,
-            'preferences': ','.join(preferences)
+            'preferences': ':'.join(preferences)
         }
         response = ApiService.api_call_helper(self, 'live_market_data', Requests.GET, params, None)
 


### PR DESCRIPTION
I was going through the documentation of the paytm client rest api https://developer.paytmmoney.com/docs/api/live-market-data-api/
I see the join on the input list in def get_live_market_data(self, mode_type, preferences : list) is joining the preferences with comma ',', but this will fail as the concatenation of the preferences.

Eg :- preferences = ['BSE','500112','EQUITY']
actual = "'BSE,500112,EQUITY"
expected = "BSE:500112:EQUITY"

with this change the fix will be applied. and we can get the live data